### PR TITLE
feat: set cors

### DIFF
--- a/src/main/java/me/synology/gooseauthapiserver/configuration/security/SecurityConfiguration.java
+++ b/src/main/java/me/synology/gooseauthapiserver/configuration/security/SecurityConfiguration.java
@@ -1,16 +1,22 @@
 package me.synology.gooseauthapiserver.configuration.security;
 
+import java.util.Arrays;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpMethod;
+import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityCustomizer;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.AuthenticationEntryPoint;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
 @RequiredArgsConstructor
 @Configuration
@@ -26,6 +32,7 @@ public class SecurityConfiguration {
     httpSecurity
         .httpBasic().disable()
         .csrf().disable()
+        .cors(Customizer.withDefaults())
         .sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS)
         .and()
         .authorizeRequests()
@@ -39,6 +46,17 @@ public class SecurityConfiguration {
             UsernamePasswordAuthenticationFilter.class);
 
     return httpSecurity.build();
+  }
+
+  @Bean
+  CorsConfigurationSource corsConfigurationSource() {
+    CorsConfiguration configuration = new CorsConfiguration();
+    configuration.setAllowedOrigins(List.of("*"));
+    configuration.setAllowedMethods(Arrays.asList("GET", "HEAD", "POST", "PUT", "PATCH", "DELETE", "OPTIONS", "TRACE"));
+    configuration.setAllowedHeaders(List.of("*"));
+    UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+    source.registerCorsConfiguration("/**", configuration);
+    return source;
   }
 
   @Bean


### PR DESCRIPTION
https://docs.spring.io/spring-security/reference/servlet/integrations/cors.html

## 테스트 방법
```sh
curl -H "Origin: http://localhost:5555" \
          -H "Access-Control-Request-Method: POST" \
          -H "x-auth-token: eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxIiwicm9sZXMiOlsiUk9MRV9VU0VSIl0sImlhdCI6MTY2MDEzNjQ3OCwiZXhwIjoxNjYwMTQwMDc4fQ.ijD9U_BgR_dXAPzb9Um1RAdznCv6PJYxFOqN65JVeYg" \
            -H "Access-Control-Request-Headers: X-Requested-With" \
              -X OPTIONS --verbose \
                https://goose-auth.synology.me/v1/users
```

## 설정 전
```sh
*   Trying 
* TCP_NODELAY set
* Connected to goose-auth.synology.me () port 443 (#0)
* ALPN, offering h2
* ALPN, offering http/1.1
* successfully set certificate verify locations:
*   CAfile: /etc/ssl/certs/ca-certificates.crt
  CApath: /etc/ssl/certs
* TLSv1.3 (OUT), TLS handshake, Client hello (1):
* TLSv1.3 (IN), TLS handshake, Server hello (2):
* TLSv1.3 (IN), TLS handshake, Encrypted Extensions (8):
* TLSv1.3 (IN), TLS handshake, Certificate (11):
* TLSv1.3 (IN), TLS handshake, CERT verify (15):
* TLSv1.3 (IN), TLS handshake, Finished (20):
* TLSv1.3 (OUT), TLS change cipher, Change cipher spec (1):
* TLSv1.3 (OUT), TLS handshake, Finished (20):
* SSL connection using TLSv1.3 / TLS_AES_256_GCM_SHA384
* ALPN, server accepted to use h2
* Server certificate:
*  subject: CN=goose-auth.synology.me
*  start date: Jul 11 08:19:06 2022 GMT
*  expire date: Oct  9 08:19:05 2022 GMT
*  subjectAltName: host "goose-auth.synology.me" matched cert's "goose-auth.synology.me"
*  issuer: C=US; O=Let's Encrypt; CN=R3
*  SSL certificate verify ok.
* Using HTTP2, server supports multi-use
* Connection state changed (HTTP/2 confirmed)
* Copying HTTP/2 data in stream buffer to connection buffer after upgrade: len=0
* Using Stream ID: 1 (easy handle 0x7fffdd553880)
> OPTIONS /v1/users HTTP/2
> Host: goose-auth.synology.me
> user-agent: curl/7.68.0
> accept: */*
> origin: http://localhost:5555
> access-control-request-method: POST
> x-auth-token: eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxIiwicm9sZXMiOlsiUk9MRV9VU0VSIl0sImlhdCI6MTY2MDEzNjQ3OCwiZXhwIjoxNjYwMTQwMDc4fQ.ijD9U_BgR_dXAPzb9Um1RAdznCv6PJYxFOqN65JVeYg
> access-control-request-headers: X-Requested-With
>
* TLSv1.3 (IN), TLS handshake, Newsession Ticket (4):
* TLSv1.3 (IN), TLS handshake, Newsession Ticket (4):
* old SSL session ID is stale, removing
* Connection state changed (MAX_CONCURRENT_STREAMS == 128)!
< HTTP/2 403
< date: Wed, 10 Aug 2022 13:11:50 GMT
< vary: Origin
< vary: Access-Control-Request-Method
< vary: Access-Control-Request-Headers
< x-content-type-options: nosniff
< x-xss-protection: 1; mode=block
< cache-control: no-cache, no-store, max-age=0, must-revalidate
< pragma: no-cache
< expires: 0
< x-frame-options: DENY
< strict-transport-security: max-age=15768000; includeSubdomains; preload
<
* Connection #0 to host goose-auth.synology.me left intact
Invalid CORS request
```

## 설정 후

```sh
*   Trying 
* TCP_NODELAY set
* Connected to goose-auth.synology.me () port 443 (#0)
* ALPN, offering h2
* ALPN, offering http/1.1
* successfully set certificate verify locations:
*   CAfile: /etc/ssl/certs/ca-certificates.crt
  CApath: /etc/ssl/certs
* TLSv1.3 (OUT), TLS handshake, Client hello (1):
* TLSv1.3 (IN), TLS handshake, Server hello (2):
* TLSv1.3 (IN), TLS handshake, Encrypted Extensions (8):
* TLSv1.3 (IN), TLS handshake, Certificate (11):
* TLSv1.3 (IN), TLS handshake, CERT verify (15):
* TLSv1.3 (IN), TLS handshake, Finished (20):
* TLSv1.3 (OUT), TLS change cipher, Change cipher spec (1):
* TLSv1.3 (OUT), TLS handshake, Finished (20):
* SSL connection using TLSv1.3 / TLS_AES_256_GCM_SHA384
* ALPN, server accepted to use h2
* Server certificate:
*  subject: CN=goose-auth.synology.me
*  start date: Jul 11 08:19:06 2022 GMT
*  expire date: Oct  9 08:19:05 2022 GMT
*  subjectAltName: host "goose-auth.synology.me" matched cert's "goose-auth.synology.me"
*  issuer: C=US; O=Let's Encrypt; CN=R3
*  SSL certificate verify ok.
* Using HTTP2, server supports multi-use
* Connection state changed (HTTP/2 confirmed)
* Copying HTTP/2 data in stream buffer to connection buffer after upgrade: len=0
* Using Stream ID: 1 (easy handle 0x7fffdef57880)
> OPTIONS /v1/users HTTP/2
> Host: goose-auth.synology.me
> user-agent: curl/7.68.0
> accept: */*
> origin: http://localhost:5555
> access-control-request-method: POST
> x-auth-token: eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxIiwicm9sZXMiOlsiUk9MRV9VU0VSIl0sImlhdCI6MTY2MDEzNjQ3OCwiZXhwIjoxNjYwMTQwMDc4fQ.ijD9U_BgR_dXAPzb9Um1RAdznCv6PJYxFOqN65JVeYg
> access-control-request-headers: X-Requested-With
>
* TLSv1.3 (IN), TLS handshake, Newsession Ticket (4):
* TLSv1.3 (IN), TLS handshake, Newsession Ticket (4):
* old SSL session ID is stale, removing
* Connection state changed (MAX_CONCURRENT_STREAMS == 128)!
< HTTP/2 200
< date: Wed, 10 Aug 2022 13:16:15 GMT
< content-length: 0
< vary: Origin
< vary: Access-Control-Request-Method
< vary: Access-Control-Request-Headers
< access-control-allow-origin: *
< access-control-allow-methods: GET,HEAD,POST,PUT,PATCH,DELETE,OPTIONS,TRACE
< access-control-allow-headers: X-Requested-With
< x-content-type-options: nosniff
< x-xss-protection: 1; mode=block
< cache-control: no-cache, no-store, max-age=0, must-revalidate
< pragma: no-cache
< expires: 0
< x-frame-options: DENY
< strict-transport-security: max-age=15768000; includeSubdomains; preload
<
* Connection #0 to host goose-auth.synology.me left intact
```