### PR TITLE
feat: dev, local yml 나눈다

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,6 +16,8 @@ services:
       - spring_cloud_vault_uri=http://vault:8200
       - spring_cloud_vault_token=insert-your-TOKEN
       - spring_profiles_active=dev
+    volumes:
+      - ./volumes/api/logs:/volumes/api/logs
 
   postgres:
     image: postgres:13

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,7 @@ services:
     environment:
       - spring_cloud_vault_uri=http://vault:8200
       - spring_cloud_vault_token=insert-your-TOKEN
+      - spring_profiles_active=dev
 
   postgres:
     image: postgres:13

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -1,0 +1,39 @@
+logging:
+  level:
+    root: warn
+    me:
+      synology:
+        gooseauthapiserver: info
+  file:
+    path: /volumes/api/logs
+
+  logback:
+    rollingpolicy:
+      max-history: 7
+
+spring:
+  datasource:
+    username: vault
+    password: vault
+    url: vault
+
+  config:
+    import: vault://
+
+  cloud:
+    vault:
+      uri: http://localhost:8200
+      token: insert-your-TOKEN
+
+  jpa:
+    show-sql: true
+    properties:
+      hibernate:
+        ddl-auth: vault
+        default_batch_fetch_size: 1000
+        format_sql: true
+
+info:
+  api:
+    id: 500
+    url: https://goose-auth.synology.me

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -1,0 +1,33 @@
+logging:
+  level:
+    root: warn
+    me:
+      synology:
+        gooseauthapiserver: debug
+
+spring:
+  datasource:
+    username: vault
+    password: vault
+    url: vault
+
+  config:
+    import: vault://
+
+  cloud:
+    vault:
+      uri: http://localhost:8200
+      token: insert-your-TOKEN
+
+  jpa:
+    show-sql: true
+    properties:
+      hibernate:
+        ddl-auth: vault
+        default_batch_fetch_size: 1000
+        format_sql: true
+
+info:
+  api:
+    id: 500
+    url: http://localhost:8080

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,28 +1,4 @@
-server:
-  port: 8080
-
 spring:
-  datasource:
-    username: vault
-    password: vault
-    url: vault
-
-  config:
-    import: vault://
-
-  cloud:
-    vault:
-      uri: http://localhost:8200
-      token: insert-your-TOKEN
-
-  jpa:
-    show-sql: true
-    properties:
-      hibernate:
-        ddl-auth: vault
-        default_batch_fetch_size: 1000
-        format_sql: true
-
   main:
     allow-bean-definition-overriding: true
 
@@ -32,11 +8,6 @@ spring:
 
   messages:
     basename: i18n/exception
-
-info:
-  api:
-    id: 500
-    url: https://goose-auth.synology.me
 
 social:
   kakao:


### PR DESCRIPTION
로그도 mount 한다

```
volumes/api/logs$ cat spring.log
2022-08-30 14:05:57.820  INFO 1 --- [main] m.s.g.GooseAuthApiServerApplication      : Starting GooseAuthApiServerApplication using Java 11.0.11 on 5eb96a8edecd with PID 1 (/app/classes started by root in /)
2022-08-30 14:05:57.829  INFO 1 --- [main] m.s.g.GooseAuthApiServerApplication      : The following 1 profile is active: "dev"
2022-08-30 14:06:11.045  WARN 1 --- [main] JpaBaseConfiguration$JpaWebConfiguration : spring.jpa.open-in-view is enabled by default. Therefore, database queries may be performed during view rendering. Explicitly configure spring.jpa.open-in-view to disable this warning
2022-08-30 14:06:17.482  WARN 1 --- [main] o.s.s.c.a.web.builders.WebSecurity       : You are asking Spring Security to ignore Ant [pattern='/v3/api-docs/**']. This is not recommended -- please use permitAll via HttpSecurity#authorizeHttpRequests instead.
2022-08-30 14:06:17.485  WARN 1 --- [main] o.s.s.c.a.web.builders.WebSecurity       : You are asking Spring Security to ignore Ant [pattern='/swagger-resources/**']. This is not recommended -- please use permitAll via HttpSecurity#authorizeHttpRequests instead.
2022-08-30 14:06:17.486  WARN 1 --- [main] o.s.s.c.a.web.builders.WebSecurity       : You are asking Spring Security to ignore Ant [pattern='/swagger-ui/**']. This is not recommended -- please use permitAll via HttpSecurity#authorizeHttpRequests instead.
2022-08-30 14:06:17.487  WARN 1 --- [main] o.s.s.c.a.web.builders.WebSecurity       : You are asking Spring Security to ignore Ant [pattern='/webjars/**']. This is not recommended -- please use permitAll via HttpSecurity#authorizeHttpRequests instead.
2022-08-30 14:06:17.487  WARN 1 --- [main] o.s.s.c.a.web.builders.WebSecurity       : You are asking Spring Security to ignore Ant [pattern='/swagger/**']. This is not recommended -- please use permitAll via HttpSecurity#authorizeHttpRequests instead.
2022-08-30 14:06:17.805  INFO 1 --- [main] m.s.g.GooseAuthApiServerApplication      : Started GooseAuthApiServerApplication in 25.055 seconds (JVM running for 27.101)
```